### PR TITLE
feat: 로그인 폼에 Zod 도입, 웹 접근성 태그 추가, 비밀번호 토글 기능

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,5 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
-
-## Getting Started
-
-First, run the development server:
-
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## 기능 명세
+### 로그인
+- [x] useActionState + Server Action
+- [x] Zod
+- [x] 웹접근성

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## 기능 명세
 ### 로그인
-- [x] useActionState + Server Action
+- [x] useActionState + 서버 액션
 - [x] Zod
 - [x] 웹접근성
+- [x] 비밀번호 보여주기/숨기기

--- a/feature/login/action/loginAction.ts
+++ b/feature/login/action/loginAction.ts
@@ -1,19 +1,16 @@
 'use server';
 
-interface loginAction {
-    success: boolean;
-    message?: string;
-}
+import { LoginSchema, type LoginState } from '../model/schema';
 
-const loginAction = async (prevState: loginAction | undefined, formData: FormData): Promise<loginAction> => {
-    const id = formData.get('id');
-    const password = formData.get('password');
+const loginAction = async (prevState: LoginState | undefined, formData: FormData): Promise<LoginState> => {
+    const rawData = Object.fromEntries(formData.entries());
+    const validatedFields = LoginSchema.safeParse(rawData);
 
-    if (!id || !password) {
+    if (!validatedFields.success) {
         return {
             success: false,
-            message: '아이디와 비밀번호를 입력해주세요.'
-        }
+            message: '아이디 또는 비밀번호를 확인해주세요.',
+        };
     }
 
     return {

--- a/feature/login/model/schema.ts
+++ b/feature/login/model/schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const LoginSchema = z.object({
+    id: z.string().trim().min(1),
+    password: z.string().min(8),
+});
+
+export type LoginState = {
+    success: boolean;
+    message?: string;
+    errors?: Partial<Record<keyof z.infer<typeof LoginSchema>, string[]>>;
+};

--- a/feature/login/ui/LoginForm.tsx
+++ b/feature/login/ui/LoginForm.tsx
@@ -16,7 +16,7 @@ const LoginForm = () => {
                 <label htmlFor="password">비밀번호</label>
                 <input type="password" name="password" id="password" />
             </div>
-            {state?.message && <p>{state?.message}</p>}
+            {state?.message && <p>{state.message}</p>}
             <button type="submit" disabled={isPending}>{isPending ? '로그인 중...' : '로그인'}</button>
         </form>
     );

--- a/feature/login/ui/LoginForm.tsx
+++ b/feature/login/ui/LoginForm.tsx
@@ -10,13 +10,27 @@ const LoginForm = () => {
         <form action={action}>
             <div>
                 <label htmlFor="id">아이디</label>
-                <input type="text" name="id" id="id" />
+                <input
+                    type="text"
+                    name="id"
+                    id="id"
+                    aria-invalid={!!state?.message}
+                    aria-describedby={state?.message ? "login-error" : undefined}
+                />
             </div>
             <div>
                 <label htmlFor="password">비밀번호</label>
-                <input type="password" name="password" id="password" />
+                <input
+                    type="password"
+                    name="password"
+                    id="password"
+                    aria-invalid={!!state?.message}
+                    aria-describedby={state?.message ? "login-error" : undefined}
+                />
             </div>
-            {state?.message && <p>{state.message}</p>}
+            <div aria-live="polite">
+                {state?.message && <p id="login-error">{state.message}</p>}
+            </div>
             <button type="submit" disabled={isPending}>{isPending ? '로그인 중...' : '로그인'}</button>
         </form>
     );

--- a/feature/login/ui/LoginForm.tsx
+++ b/feature/login/ui/LoginForm.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useActionState } from "react";
+import { useState, useActionState } from "react";
 import loginAction from "../action/loginAction";
 
 const LoginForm = () => {
+    const [showPassword, setShowPassword] = useState(false);
     const [state, action, isPending] = useActionState(loginAction, undefined);
 
     return (
         <form action={action}>
+            {/* 아이디 */}
             <div>
                 <label htmlFor="id">아이디</label>
                 <input
@@ -18,19 +20,34 @@ const LoginForm = () => {
                     aria-describedby={state?.message ? "login-error" : undefined}
                 />
             </div>
+
+            {/* 비밀번호 */}
             <div>
                 <label htmlFor="password">비밀번호</label>
-                <input
-                    type="password"
-                    name="password"
-                    id="password"
-                    aria-invalid={!!state?.message}
-                    aria-describedby={state?.message ? "login-error" : undefined}
-                />
+                <div>
+                    <input
+                        type={showPassword ? "text" : "password"}
+                        name="password"
+                        id="password"
+                        aria-invalid={!!state?.message}
+                        aria-describedby={state?.message ? "login-error" : undefined}
+                    />
+                    <button
+                        type="button"
+                        onClick={() => setShowPassword(!showPassword)}
+                        aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 보이기"}
+                    >
+                        {showPassword ? "🙈" : "👁️"}
+                    </button>
+                </div>
             </div>
+
+            {/* 에러 메시지 */}
             <div aria-live="polite">
                 {state?.message && <p id="login-error">{state.message}</p>}
             </div>
+
+            {/* 로그인 버튼 */}
             <button type="submit" disabled={isPending}>{isPending ? '로그인 중...' : '로그인'}</button>
         </form>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "16.1.1",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "zod": "^4.3.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6515,7 +6516,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.4.tgz",
       "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "16.1.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "zod": "^4.3.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## 요약

로그인 기능을 리팩토링하여 Zod v4를 사용하여 강력한 서버 측 검증을 구현하고, 화면 리더를 위한 웹 접근성(A11y)을 개선했으며, 더 나은 UX를 위해 비밀번호 가시성 토글을 추가했습니다.

## 주요 변경 사항
- 서버 측 검증을 위한 통합 조드 로그인 액션 스키마를 더 나은 모듈화를 위해 전용 모델 디렉토리로 추출했습니다.
- 사용자 열거 공격을 방지하기 위해 로그인 실패에 대한 "보안 글로벌 메시지" 패턴을 구현했습니다.
- 입력을 오류 메시지와 연결하기 위해 aria-invalid와 aria-descripted by를 추가했습니다. 실시간 오류 알림을 위해 aria-live="polite"를 구현했습니다. 키보드 내비게이션과 VoiceOver 호환성을 확인했습니다.
- useState를 사용하여 비밀번호 콘텐츠를 표시/숨기기 위해 토글 버튼을 추가했습니다.