### PR TITLE
refactor: /refresh API와 사일런트 리프레쉬 로직 향상

### DIFF
--- a/app/api/backend/login/route.ts
+++ b/app/api/backend/login/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
 
-import { SignJWT } from 'jose';
+import { createAccessToken, createRefreshToken } from '../shared/utils/token';
+
+import { readJsonDb } from '@/app/api/database/shared/utils/readJsonDb';
 
 import { ERROR_MESSAGES } from '@/app/api/backend/shared/constants/errorMessages';
-import { readJsonDb } from '../../database/shared/utils/readJsonDb';
-
-const JWT_SECRET = new TextEncoder().encode(process.env.JWT_SECRET) || "MOCK_JWT_SECRET";
 
 export async function POST(request: Request) {
     try {
@@ -26,17 +25,8 @@ export async function POST(request: Request) {
         }
 
         // JWT 토큰 생성
-        const accessToken = await new SignJWT({ user_id: user.user_id, role: user.role, name: user.name })
-            .setProtectedHeader({ alg: 'HS256' })
-            .setIssuedAt()
-            .setExpirationTime('1h')
-            .sign(JWT_SECRET);
-
-        const refreshToken = await new SignJWT({ user_id: user.user_id, sid: "MOCK_SID" })
-            .setProtectedHeader({ alg: 'HS256' })
-            .setIssuedAt()
-            .setExpirationTime('7d')
-            .sign(JWT_SECRET);
+        const accessToken = await createAccessToken({ user_id: user.user_id, role: user.role, name: user.name });
+        const refreshToken = await createRefreshToken(user.user_id);
 
         return NextResponse.json({ success: true, data: { user, accessToken, refreshToken }, error: null }, { status: 200 });
 

--- a/app/api/backend/refresh/route.ts
+++ b/app/api/backend/refresh/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
-import { SignJWT, jwtVerify } from 'jose';
-import { ERROR_MESSAGES } from '@/app/api/backend/shared/constants/errorMessages';
+import { jwtVerify } from 'jose';
+import { createAccessToken, createRefreshToken } from '../shared/utils/token';
 
 import { readJsonDb } from '@/app/api/database/shared/utils/readJsonDb';
 
-const JWT_SECRET = new TextEncoder().encode(process.env.JWT_SECRET) || "MOCK_JWT_SECRET";
+import { ERROR_MESSAGES } from '@/app/api/backend/shared/constants/errorMessages';
+import { JWT_SECRET } from '@/app/api/backend/shared/constants/jwtSecret';
 
 export async function POST(request: Request) {
     try {
@@ -30,17 +31,8 @@ export async function POST(request: Request) {
         }
 
         // JWT 토큰 생성
-        const accessToken = await new SignJWT({ user_id: user.user_id, role: user.role, name: user.name })
-            .setProtectedHeader({ alg: 'HS256' })
-            .setIssuedAt()
-            .setExpirationTime('1h')
-            .sign(JWT_SECRET);
-
-        const newRefreshToken = await new SignJWT({ user_id: user.user_id, sid: "MOCK_SID" })
-            .setProtectedHeader({ alg: 'HS256' })
-            .setIssuedAt()
-            .setExpirationTime('7d')
-            .sign(JWT_SECRET);
+        const accessToken = await createAccessToken({ user_id: user.user_id, role: user.role, name: user.name });
+        const newRefreshToken = await createRefreshToken(user.user_id);
 
         return NextResponse.json({
             success: true,

--- a/app/api/backend/refresh/route.ts
+++ b/app/api/backend/refresh/route.ts
@@ -1,31 +1,42 @@
 import { NextResponse } from 'next/server';
 import { SignJWT, jwtVerify } from 'jose';
-import { ERROR_MESSAGES } from '@/shared/constants/errorMessages';
+import { ERROR_MESSAGES } from '@/app/api/backend/shared/constants/errorMessages';
 
-import { JWT_SECRET } from '@/shared/constants/auth';
+import { readJsonDb } from '@/app/api/database/shared/utils/readJsonDb';
+
+const JWT_SECRET = new TextEncoder().encode(process.env.JWT_SECRET) || "MOCK_JWT_SECRET";
 
 export async function POST(request: Request) {
     try {
         const body = await request.json();
         const { refreshToken } = body;
 
+        // 입력값 확인
         if (!refreshToken) {
-            return NextResponse.json({ message: ERROR_MESSAGES.EXPIRED_TOKEN }, { status: 401 });
+            return NextResponse.json({ success: false, data: null, error: { code: ERROR_MESSAGES.INVALID_TOKEN.code, message: ERROR_MESSAGES.INVALID_TOKEN.message, details: [] } }, { status: 401 });
         }
 
-        // 1. 리프레쉬 토큰 검증
-        const { payload } = await jwtVerify(refreshToken, JWT_SECRET);
-        const userId = payload.id as string;
+        // 리프레쉬 토큰 검증 - 실패하면 바로 catch로 이동
+        const { payload } = await jwtVerify(refreshToken, JWT_SECRET)
 
-        // 2. 새로운 액세스 토큰 생성
-        const accessToken = await new SignJWT({ id: userId, role: payload.role }) // 실제로는 DB에서 정보를 다시 가져오는 게 정석입니다.
+        // DB에서 사용자 정보 조회
+        const userId = payload.user_id;
+
+        const allUsers = await readJsonDb('app/api/database/data/user.json');
+        const user = allUsers.find((u: { user_id: string }) => u.user_id === userId);
+
+        if (!user) {
+            return NextResponse.json({ success: false, data: null, error: { code: ERROR_MESSAGES.INVALID_TOKEN.code, message: ERROR_MESSAGES.INVALID_TOKEN.message, details: [] } }, { status: 401 });
+        }
+
+        // JWT 토큰 생성
+        const accessToken = await new SignJWT({ user_id: user.user_id, role: user.role, name: user.name })
             .setProtectedHeader({ alg: 'HS256' })
             .setIssuedAt()
-            .setExpirationTime('15m')
+            .setExpirationTime('1h')
             .sign(JWT_SECRET);
 
-        // 3. 새로운 리프레쉬 토큰 생성
-        const newRefreshToken = await new SignJWT({ id: userId, sid: payload.sid })
+        const newRefreshToken = await new SignJWT({ user_id: user.user_id, sid: "MOCK_SID" })
             .setProtectedHeader({ alg: 'HS256' })
             .setIssuedAt()
             .setExpirationTime('7d')
@@ -33,11 +44,14 @@ export async function POST(request: Request) {
 
         return NextResponse.json({
             success: true,
-            accessToken,
-            refreshToken: newRefreshToken
+            data: {
+                accessToken,
+                refreshToken: newRefreshToken
+            },
+            error: null
         }, { status: 200 });
 
     } catch (error) {
-        return NextResponse.json({ message: ERROR_MESSAGES.EXPIRED_TOKEN }, { status: 401 });
+        return NextResponse.json({ success: false, data: null, error: { code: ERROR_MESSAGES.INVALID_TOKEN.code, message: ERROR_MESSAGES.INVALID_TOKEN.message, details: [] } }, { status: 401 });
     }
 }

--- a/app/api/backend/shared/constants/errorMessages.ts
+++ b/app/api/backend/shared/constants/errorMessages.ts
@@ -4,6 +4,11 @@ export const ERROR_MESSAGES = {
         message: "유효하지 않은 입력값입니다.",
         details: []
     },
+    INVALID_TOKEN: {
+        code: "INVALID_TOKEN",
+        message: "유효하지 않은 토큰입니다.",
+        details: []
+    },
     AUTH_FAILED: {
         code: "AUTH_FAILED",
         message: "아이디 혹은 비밀번호를 확인해주세요.",

--- a/app/api/backend/shared/constants/jwtSecret.ts
+++ b/app/api/backend/shared/constants/jwtSecret.ts
@@ -1,0 +1,1 @@
+export const JWT_SECRET = new TextEncoder().encode(process.env.JWT_SECRET || "MOCK_JWT_SECRET");

--- a/app/api/backend/shared/utils/token.ts
+++ b/app/api/backend/shared/utils/token.ts
@@ -1,0 +1,24 @@
+import { SignJWT } from 'jose';
+import { JWT_SECRET } from '../constants/jwtSecret';
+
+interface UserPayload {
+    user_id: string;
+    role?: string;
+    name?: string;
+}
+
+export const createAccessToken = (user: UserPayload) => {
+    return new SignJWT({ user_id: user.user_id, role: user.role, name: user.name })
+        .setProtectedHeader({ alg: 'HS256' })
+        .setIssuedAt()
+        .setExpirationTime('1h')
+        .sign(JWT_SECRET);
+};
+
+export const createRefreshToken = (user_id: string) => {
+    return new SignJWT({ user_id, sid: "MOCK_SID" })
+        .setProtectedHeader({ alg: 'HS256' })
+        .setIssuedAt()
+        .setExpirationTime('7d')
+        .sign(JWT_SECRET);
+};

--- a/feature/login/action/loginAction.ts
+++ b/feature/login/action/loginAction.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { setAuthCookies } from '@/shared/api/setAuthCookies';
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { HttpError } from '@/shared/api/HttpError';
@@ -34,7 +35,7 @@ const loginAction = async (prevState: LoginState | undefined, formData: FormData
         const { data: { accessToken, refreshToken } } = response;
 
         if (accessToken && refreshToken) {
-            await setAuthCookies(accessToken, refreshToken);
+            await setAuthCookies(await cookies(), accessToken, refreshToken);
         }
     } catch (error) {
         if (!(error instanceof HttpError)) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,56 +1,38 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
+import { serverClient } from './shared/api/serverClient';
+import { setAuthCookies } from './shared/api/setAuthCookies';
+
 export async function proxy(request: NextRequest) {
-    // 토큰 여부 확인
     const accessToken = request.cookies.get('accessToken')?.value;
     const refreshToken = request.cookies.get('refreshToken')?.value;
 
-    // 1. 토큰이 둘 다 없으면 로그인 페이지로 리다이렉트
+    // 토큰 X -> 로그인
     if (!accessToken && !refreshToken) {
         return NextResponse.redirect(new URL('/login', request.url));
     }
 
-    // 2. 액세스 토큰은 없으나 리프레쉬 토큰이 있는 경우 (사일런트 리프레쉬)
+    // 리프레쉬만 O -> 사일런트 리프레쉬
     if (!accessToken && refreshToken) {
         try {
-            const response = await fetch(`${new URL(request.url).origin}/api/backend/refresh`, {
+            const response = await serverClient(`/refresh`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ refreshToken }),
             });
 
-            if (response.ok) {
-                const data = await response.json();
-                const { accessToken: newAccess, refreshToken: newRefresh } = data;
+            const { data: { accessToken: newAccessToken, refreshToken: newRefreshToken } } = response;
 
-                const nextResponse = NextResponse.next();
+            const nextResponse = NextResponse.next();
 
-                // 새로운 토큰들을 쿠키에 설정
-                const cookieOptions = {
-                    httpOnly: true,
-                    secure: process.env.NODE_ENV === 'production',
-                    sameSite: 'lax' as const,
-                    path: '/',
-                };
+            await setAuthCookies(nextResponse.cookies, newAccessToken, newRefreshToken);
 
-                nextResponse.cookies.set('accessToken', newAccess, {
-                    ...cookieOptions,
-                    maxAge: 15 * 60,
-                });
-                nextResponse.cookies.set('refreshToken', newRefresh, {
-                    ...cookieOptions,
-                    maxAge: 60 * 60 * 24 * 7,
-                });
-
-                return nextResponse;
-            }
+            return nextResponse;
         } catch (error) {
-            console.error('Middleware refresh error:', error);
+            console.error(error);
+            return NextResponse.redirect(new URL('/login', request.url));
         }
-
-        // 리프레쉬 실패 시 로그인 페이지로
-        return NextResponse.redirect(new URL('/login', request.url));
     }
 
     return NextResponse.next();

--- a/shared/api/setAuthCookies.ts
+++ b/shared/api/setAuthCookies.ts
@@ -1,23 +1,24 @@
 import 'server-only';
 
-import { cookies } from 'next/headers';
+interface CookieStore {
+    set: (name: string, value: string, options: any) => void;
+}
 
-export const setAuthCookies = async (accessToken: string, refreshToken: string) => {
-    const cookieStore = await cookies();
+export const setAuthCookies = async (cookieStore: CookieStore, accessToken: string, refreshToken: string) => {
+    const cookieOptions = {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax' as const,
+        path: '/',
+    };
 
     cookieStore.set('accessToken', accessToken, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === 'production',
-        path: '/',
+        ...cookieOptions,
         maxAge: 60 * 60, // 1 hour
     });
 
     cookieStore.set('refreshToken', refreshToken, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === 'production',
-        path: '/',
+        ...cookieOptions,
         maxAge: 60 * 60 * 24 * 7, // 7 days
     });
 };


### PR DESCRIPTION
- /refresh API 응답 표준으로 변경
- jwtSecret 변수 추가
- 서버 에러 코드에 INVALID_TOKEN 추가
- token 유틸함수를 만들어 JWT 토큰 생성 로직 관리
- setAuthCookie 유틸함수에 쿠키 파라미터를 추가하고 async로 변경해 proxy에서도 사용 가능하도록 변경
- proxy 코드 가독성 향상

close: #16 