### PR TITLE
bug: 서버 컴포넌트에서 토큰 사일런트 리프레쉬

### DIFF
--- a/app/(private)/result/[code]/[id]/page.tsx
+++ b/app/(private)/result/[code]/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { getResult } from "@/feature/result/api/getResult";
 
-
 const ResultPage = async ({ params }: { params: Promise<{ id: string, code: string }> }) => {
     const { id } = await params;
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,42 +1,31 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-import { HttpError } from './shared/api/HttpError';
+import { refreshTokens } from './shared/api/refreshTokens';
 import { setAuthCookies } from './shared/api/setAuthCookies';
 
 export async function proxy(request: NextRequest) {
     const accessToken = request.cookies.get('accessToken')?.value;
     const refreshToken = request.cookies.get('refreshToken')?.value;
 
-    // 토큰 X -> 로그인
+    // 액세스 토큰, 리프레쉬 토큰 모두 없을 때 -> 로그인
     if (!accessToken && !refreshToken) {
         return NextResponse.redirect(new URL('/login', request.url));
     }
 
-    // 리프레쉬만 O -> 사일런트 리프레쉬
+    // 리프레쉬만 있을 때 -> 사일런트 리프레쉬
     if (!accessToken && refreshToken) {
         try {
-            // 런타임 에러 방지를 위해 serverClient 사용X
-            const response = await fetch(`${process.env.BASE_URL}/backend/refresh`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ refreshToken }),
-            });
-
-            const result = await response.json();
-
-            if (!response.ok) {
-                throw new HttpError(response.status, result.error.code, result.error.message);
-            }
-
+            // 리프레쉬 토큰으로 토큰 갱신
+            const result = await refreshTokens(refreshToken);
             const { data: { accessToken: newAccessToken, refreshToken: newRefreshToken } } = result;
 
+            // 쿠키 저장
             const nextResponse = NextResponse.next();
-
             await setAuthCookies(nextResponse.cookies, newAccessToken, newRefreshToken);
-
             return nextResponse;
         } catch (error) {
+            // 리프레쉬 토큰 만료 -> 로그인
             console.error(error);
             return NextResponse.redirect(new URL('/login', request.url));
         }

--- a/proxy.ts
+++ b/proxy.ts
@@ -48,5 +48,7 @@ export async function proxy(request: NextRequest) {
 export const config = {
     matcher: [
         '/dashboard/:path*',
+        '/test/:path*',
+        '/result/:path*'
     ],
 };

--- a/shared/api/refreshTokens.ts
+++ b/shared/api/refreshTokens.ts
@@ -1,0 +1,23 @@
+import { HttpError } from "./HttpError";
+
+export const refreshTokens = async (refreshToken: string) => {
+    const response = await fetch(`${process.env.BASE_URL}/backend/refresh`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ refreshToken }),
+    });
+
+    const result = await response.json();
+
+    if (!response.ok) {
+        throw new HttpError(
+            response.status,
+            result.error.code,
+            result.error.message
+        );
+    }
+
+    return result;
+};

--- a/shared/api/serverClient.ts
+++ b/shared/api/serverClient.ts
@@ -1,6 +1,8 @@
 import 'server-only';
 
 import { cookies } from "next/headers";
+import { redirect } from 'next/navigation';
+
 import { HttpError } from './HttpError';
 
 export const serverClient = async (url: string, options: RequestInit = {}) => {
@@ -16,17 +18,25 @@ export const serverClient = async (url: string, options: RequestInit = {}) => {
         headers['Authorization'] = `Bearer ${accessToken}`;
     }
 
-    // API 호출
-    const response = await fetch(`${process.env.BASE_URL}/backend${url}`, {
-        ...options,
-        headers,
-    });
+    try {
+        // API 호출
+        const response = await fetch(`${process.env.BASE_URL}/backend${url}`, {
+            ...options,
+            headers,
+        });
 
-    const result = await response.json();
+        const result = await response.json();
 
-    if (!response.ok) {
-        throw new HttpError(response.status, result.error.code, result.error.message);
+        if (!response.ok) {
+            throw new HttpError(response.status, result.error.code, result.error.message);
+        }
+
+        return result;
+    } catch (error) {
+        if (error instanceof HttpError) {
+            if (error.status === 401) {
+                redirect('/login');
+            }
+        }
     }
-
-    return result;
 }


### PR DESCRIPTION
## Solution

서버 컴포넌트 내부에서 accessToken이 만료됐을 경우를 가정해 토큰 갱신 로직을 추가하려고 했다. 하지만 몇 가지 문제가 발생했다. 먼저, 서버 컴포넌트는 쿠키 읽기 전용이기 때문에 내부에서 쿠키를 업데이트할 수가 없다. 서버 환경에서 쿠키를 업데이트하기 위해서는 프록시, 라우트 핸들러, 서버 액션 중에 하나를 사용해야 했다. 내가 가정한 상황은 사용자가 특정 라우트에 너무 오래 머물려 accessToken이 초기화된 상태를 고려한 것이었다. 여기에서 문제가 발생했다.

단순한 GET 요청을 하는 경우라면 처음에 페이지가 로딩이 됐을 때 필요한 데이터를 이미 불러왔을 것이라 토큰 만료가 발생해 문제가 생길 일은 없다. 사용자가 새로 고침을 한다면 proxy에 설정해둔 리프레쉬 로직이 동작하기 때문이다. 질문이 잘못됐다는 것을 깨달은 것은 한참의 삽질 후였다. 

내가 가정하는 상황의 문제는 서버 컴포넌트에서 바로 실행되는 GET 요청에서 발생하지 않고, 클라이언트 컴포넌트를 활용한 통신에서 주로 발생될 확률이 높았다. 이런 경우에는 라우트 핸들러를 활용한 통신을 하거나 아니면 서버 액션을 수행하는 게 올바른 선택으로 보인다.

1. proxy의 매처에 인증이 필요한 라우트를 추가했다.
2. serverClient에 있던 리프레쉬 토큰 로직을 제거하는 대신에 401 응답이 돌아올 경우 login 페이지로 보내도록 했다.

## Refer
Close: #43 