### PR TITLE
feat: 로그인 상태에 따른 라우트 접근 분리

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -50,6 +50,10 @@ export async function proxy(request: NextRequest) {
             // 리프레쉬 토큰 만료 -> 로그인
             console.error(error);
 
+            // 쿠키 삭제
+            request.cookies.delete('accessToken');
+            request.cookies.delete('refreshToken');
+
             return NextResponse.redirect(new URL('/login', request.url));
         }
     }

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,9 +4,31 @@ import type { NextRequest } from 'next/server';
 import { refreshTokens } from './shared/api/refreshTokens';
 import { setAuthCookies } from './shared/api/setAuthCookies';
 
+const PUBLIC_ROUTE = ["/", "/login"]
+
 export async function proxy(request: NextRequest) {
+    // 현재 경로 확인
+    const { pathname } = request.nextUrl;
+
+    // 퍼블릭 라우트인지 확인
+    const isPublicRoute = PUBLIC_ROUTE.includes(pathname);
+
+    // 쿠키에서 토큰 가져오기
     const accessToken = request.cookies.get('accessToken')?.value;
     const refreshToken = request.cookies.get('refreshToken')?.value;
+
+    // 로그인 상태 확인
+    const isLoggedIn = !!accessToken || !!refreshToken;
+
+    // 로그인 O -> 대시보드
+    if (isPublicRoute && isLoggedIn) {
+        return NextResponse.redirect(new URL('/dashboard', request.url));
+    }
+
+    // 로그인 X -> 퍼블릭 라우트만 허용
+    if (isPublicRoute) {
+        return NextResponse.next();
+    }
 
     // 액세스 토큰, 리프레쉬 토큰 모두 없을 때 -> 로그인
     if (!accessToken && !refreshToken) {
@@ -27,6 +49,7 @@ export async function proxy(request: NextRequest) {
         } catch (error) {
             // 리프레쉬 토큰 만료 -> 로그인
             console.error(error);
+
             return NextResponse.redirect(new URL('/login', request.url));
         }
     }
@@ -36,6 +59,8 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
     matcher: [
+        '/',
+        '/login',
         '/dashboard/:path*',
         '/test/:path*',
         '/result/:path*'


### PR DESCRIPTION
## Solution

사용자가 로그인에 성공했을 경우에는 `/dashboard`를 기준으로 인증된 라우트에만 머무르도록 하고, 로그인이 아닌 상태에는 공개된 라우트에만 머무르도록 한다.

1. proxy의 matcher에 공개 라우트를 추가하고 로그인 상태에 따른 페이지 이동 기능 추가
2. 토큰 재발급에 실패할 경우 혹시 모를 잔류 쿠키를 제거하도록 함

## Refer

Close: #48 